### PR TITLE
Implement show

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ An opinionated wrapper around git to provide a more friendly experience. Makes c
 ## Running it
 Build the executable and then run it:
 ```
-$ go build gg.go
-$ ./gg
+$ go build -o gg
+$ ./gg -h
 ```
 
 ## Command Line Interface

--- a/gg.go
+++ b/gg.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"os"
 
+	commands "github.com/thoiberg/good-git/internal/commands"
 	"github.com/urfave/cli/v2"
 )
 
@@ -19,6 +20,7 @@ func main() {
 				Usage:     "[INCOMPLETE] shows the local and remote branches. Can switch to the branch by entering the number",
 				UsageText: "gg show",
 				Action: func(c *cli.Context) error {
+					commands.Show()
 					return cli.Exit("Still being built!", 1)
 				},
 			},

--- a/gg.go
+++ b/gg.go
@@ -20,8 +20,13 @@ func main() {
 				Usage:     "[INCOMPLETE] shows the local and remote branches. Can switch to the branch by entering the number",
 				UsageText: "gg show",
 				Action: func(c *cli.Context) error {
-					commands.Show()
-					return cli.Exit("Still being built!", 1)
+					message, err := commands.Show()
+
+					if err != nil {
+						return cli.Exit(err, 1)
+					}
+
+					return cli.Exit(message, 0)
 				},
 			},
 			{

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/thoiberg/good-git
 
 go 1.14
 
-require github.com/urfave/cli/v2 v2.1.1
+require (
+	github.com/fatih/color v1.9.0
+	github.com/urfave/cli/v2 v2.1.1
+)

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,13 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
+github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
+github.com/mattn/go-colorable v0.1.4 h1:snbPLB8fVfU9iwbbo30TPtbLRzwWu6aJS6Xh4eaaviA=
+github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
+github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
+github.com/mattn/go-isatty v0.0.11 h1:FxPOTFNqGkuDUGi3H/qkUbQO4ZiBa2brKq5r0l8TGeM=
+github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOAqxQCu2WE=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -9,5 +16,7 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeV
 github.com/urfave/cli v1.22.2 h1:gsqYFH8bb9ekPA12kRo0hfjngWQjkJPlN9R0N78BoUo=
 github.com/urfave/cli/v2 v2.1.1 h1:Qt8FeAtxE/vfdrLmR3rxR6JRE0RoVmbXu8+6kZtYU4k=
 github.com/urfave/cli/v2 v2.1.1/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
+golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/internal/commands/show.go
+++ b/internal/commands/show.go
@@ -35,7 +35,7 @@ func Show() {
 
 	// listen for input
 	reader := bufio.NewReader(os.Stdin)
-	fmt.Print("Enter text: ")
+	fmt.Print("Enter the number next to the branch name to switch: ")
 	text, _ := reader.ReadString('\n')
 
 	inputInt, err := strconv.Atoi(strings.TrimSuffix(text, "\n"))

--- a/internal/commands/show.go
+++ b/internal/commands/show.go
@@ -48,7 +48,7 @@ func Show() (string, error) {
 
 	// checkout the branch
 	branchToCheckout := normalisedBranchNames[branchNumberToCheckout]
-	gitCheckoutCmd := exec.Command("git", "checkout", strings.TrimSpace(branchToCheckout))
+	gitCheckoutCmd := exec.Command("git", "checkout", branchToCheckout)
 	gitCheckoutStdStderr, gitCheckoutErr := gitCheckoutCmd.CombinedOutput()
 
 	if gitCheckoutErr != nil {
@@ -75,7 +75,7 @@ func normaliseGitBranchOutput(branches []string) []string {
 			trimmedBranch := strings.TrimSpace(branch)
 			if isCurrentBranch(trimmedBranch) {
 				onlyBranchName := strings.Replace(trimmedBranch, "* ", "", 1)
-				coloredBranchName := color.GreenString("%v", onlyBranchName)
+				coloredBranchName := color.GreenString(onlyBranchName)
 				normalisedBranchNames = append(normalisedBranchNames, coloredBranchName)
 			} else {
 				normalisedBranchNames = append(normalisedBranchNames, trimmedBranch)

--- a/internal/commands/show.go
+++ b/internal/commands/show.go
@@ -22,21 +22,21 @@ func Show() (string, error) {
 
 	branches := strings.Split(bytesToString(gitBranchesStdoutStderr), "\n")
 
-	var onlyBranchNames []string
+	var normalisedBranchNames []string
 
-	for _, branchName := range branches {
-		if len(branchName) > 0 {
-			onlyBranchNames = append(onlyBranchNames, branchName)
+	for _, branch := range branches {
+		if len(branch) > 0 {
+			if isCurrentBranch(branch) {
+				onlyBranchName := strings.Replace(branch, "* ", "", 1)
+				coloredBranchName := color.GreenString(onlyBranchName)
+				normalisedBranchNames = append(normalisedBranchNames, coloredBranchName)
+			}
+			normalisedBranchNames = append(normalisedBranchNames, branch)
 		}
 	}
 
-	for index, branch := range onlyBranchNames {
-		if isCurrentBranch(branch) {
-			normalisedBranchName := strings.Replace(branch, "* ", "", 1)
-			color.Green("%d)   %v\n", index, normalisedBranchName)
-		} else {
-			fmt.Printf("%d) %v\n", index, branch)
-		}
+	for index, branch := range normalisedBranchNames {
+		fmt.Printf("%d) %v\n", index, branch)
 	}
 
 	// listen for input
@@ -49,11 +49,11 @@ func Show() (string, error) {
 		return "", errors.New("input must be a number")
 	}
 
-	if inputInt < 0 || inputInt > len(onlyBranchNames)-1 {
+	if inputInt < 0 || inputInt > len(normalisedBranchNames)-1 {
 		return "", errors.New("Branch number is invalid. Please enter one of the numbers next to the branch number")
 	}
 
-	branchToCheckout := onlyBranchNames[inputInt]
+	branchToCheckout := normalisedBranchNames[inputInt]
 	gitCheckoutCmd := exec.Command("git", "checkout", strings.TrimSpace(branchToCheckout))
 	gitCheckoutStdStderr, gitCheckoutErr := gitCheckoutCmd.CombinedOutput()
 

--- a/internal/commands/show.go
+++ b/internal/commands/show.go
@@ -22,7 +22,7 @@ func Show() {
 	gitCurrentBranchStdoutStderr, gitCurrentBranchErr := gitCurrentBranchCmd.CombinedOutput()
 
 	if gitCurrentBranchErr != nil {
-		log.Fatal(gitCurrentBranchErr)
+		log.Fatal(gitCurrentBranchStdoutStderr)
 	}
 
 	branches := strings.Split(bytesToString(gitBranchesStdoutStderr), "\n")

--- a/internal/commands/show.go
+++ b/internal/commands/show.go
@@ -22,14 +22,20 @@ func Show() {
 
 	branches := strings.Split(bytesToString(gitBranchesStdoutStderr), "\n")
 
-	for index, branch := range branches {
-		if len(branch) > 0 {
-			if isCurrentBranch(branch) {
-				normalisedBranchName := strings.Replace(branch, "* ", "", 1)
-				color.Green("%d)   %v\n", index, normalisedBranchName)
-			} else {
-				fmt.Printf("%d) %v\n", index, branch)
-			}
+	var onlyBranchNames []string
+
+	for _, branchName := range branches {
+		if len(branchName) > 0 {
+			onlyBranchNames = append(onlyBranchNames, branchName)
+		}
+	}
+
+	for index, branch := range onlyBranchNames {
+		if isCurrentBranch(branch) {
+			normalisedBranchName := strings.Replace(branch, "* ", "", 1)
+			color.Green("%d)   %v\n", index, normalisedBranchName)
+		} else {
+			fmt.Printf("%d) %v\n", index, branch)
 		}
 	}
 
@@ -42,9 +48,12 @@ func Show() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	// TODO: Need to handle when the input is not within the valid range
 
-	branchToCheckout := branches[inputInt]
+	if inputInt < 0 || inputInt > len(onlyBranchNames)-1 {
+		log.Fatal("Branch number is invalid. Please enter one of the numbers next to the branch number")
+	}
+
+	branchToCheckout := onlyBranchNames[inputInt]
 	gitCheckoutCmd := exec.Command("git", "checkout", strings.TrimSpace(branchToCheckout))
 	gitCheckoutStdStderr, gitCheckoutErr := gitCheckoutCmd.CombinedOutput()
 

--- a/internal/commands/show.go
+++ b/internal/commands/show.go
@@ -1,0 +1,76 @@
+package commands
+
+import (
+	"bufio"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func Show() {
+	gitBranchesCmd := exec.Command("git", "branch", "--list")
+	gitBranchesStdoutStderr, gitBranchesErr := gitBranchesCmd.CombinedOutput()
+
+	if gitBranchesErr != nil {
+		log.Fatal(gitBranchesErr)
+	}
+
+	gitCurrentBranchCmd := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
+	gitCurrentBranchStdoutStderr, gitCurrentBranchErr := gitCurrentBranchCmd.CombinedOutput()
+
+	if gitCurrentBranchErr != nil {
+		log.Fatal(gitCurrentBranchErr)
+	}
+
+	fmt.Printf("all branches: %q\n", gitBranchesStdoutStderr)
+	fmt.Printf("current branch: %q\n", gitCurrentBranchStdoutStderr)
+
+	// split all branches on \n
+	branches := strings.Split(bytesToString(gitBranchesStdoutStderr), "\n")
+	// remove the * from the current branch
+
+	fmt.Printf("total amount of branches is: %d\n", len(branches))
+	// map each branch with it's index
+	for index, element := range branches {
+		fmt.Println("mapping the branches:")
+		if len(element) > 0 {
+			fmt.Printf("%d) %v\n", index, element)
+		}
+	}
+
+	// listen for input
+	reader := bufio.NewReader(os.Stdin)
+	fmt.Print("Enter text: ")
+	text, _ := reader.ReadString('\n')
+	fmt.Printf("input: %v", text)
+	// if input matches a branch number:
+	inputInt, err := strconv.Atoi(strings.TrimSuffix(text, "\n"))
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	branchToCheckout := branches[inputInt]
+
+	fmt.Println("branch to checkout:")
+	fmt.Println(branchToCheckout)
+	fmt.Println(len(branchToCheckout))
+	fmt.Println(len(strings.TrimSpace(branchToCheckout)))
+	// checkout that branch
+	gitCheckoutCmd := exec.Command("git", "checkout", strings.TrimSpace(branchToCheckout))
+	gitCheckoutStdStderr, gitCheckoutErr := gitCheckoutCmd.CombinedOutput()
+
+	if gitCheckoutErr != nil {
+		log.Fatal(gitCheckoutErr)
+	}
+
+	fmt.Printf("blah: %q", gitCheckoutStdStderr)
+}
+
+// https://gist.github.com/is73/de4f38e1d8da157fe33e
+func bytesToString(data []byte) string {
+	return string(data[:])
+}

--- a/internal/commands/show.go
+++ b/internal/commands/show.go
@@ -20,13 +20,6 @@ func Show() {
 		log.Fatal(bytesToString(gitBranchesStdoutStderr))
 	}
 
-	gitCurrentBranchCmd := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
-	gitCurrentBranchStdoutStderr, gitCurrentBranchErr := gitCurrentBranchCmd.CombinedOutput()
-
-	if gitCurrentBranchErr != nil {
-		log.Fatal(gitCurrentBranchStdoutStderr)
-	}
-
 	branches := strings.Split(bytesToString(gitBranchesStdoutStderr), "\n")
 
 	for index, branch := range branches {

--- a/internal/commands/show.go
+++ b/internal/commands/show.go
@@ -33,11 +33,19 @@ func Show() (string, error) {
 
 	var normalisedBranchNames = normaliseGitBranchOutput(branches)
 
+	numberOfBranches := len(normalisedBranchNames)
+
+	cols := 1
+
+	if numberOfBranches > 9 {
+		cols = 2
+	}
+
 	for index, branch := range normalisedBranchNames {
 		if branch == currentBranch {
-			color.Green("%d)\t%v\n", index, branch)
+			color.Green("%s)\t%v\n", alignRight(index, cols), branch)
 		} else {
-			fmt.Printf("%d)\t%v\n", index, branch)
+			fmt.Printf("%s)\t%v\n", alignRight(index, cols), branch)
 		}
 	}
 
@@ -76,10 +84,6 @@ func bytesToString(data []byte) string {
 	return string(data[:])
 }
 
-func isCurrentBranch(s string) bool {
-	return strings.HasPrefix(s, "*")
-}
-
 func normaliseGitBranchOutput(branches []string) []string {
 	var normalisedBranchNames []string
 
@@ -92,4 +96,13 @@ func normaliseGitBranchOutput(branches []string) []string {
 	}
 
 	return normalisedBranchNames
+}
+
+func alignRight(input int, columns int) string {
+	str := strconv.Itoa(input)
+	if input < 10 && columns == 2 {
+		return " " + str
+	} else {
+		return str
+	}
 }

--- a/internal/commands/show.go
+++ b/internal/commands/show.go
@@ -40,21 +40,25 @@ func Show() (string, error) {
 		fmt.Printf("%d) %v\n", index, branch)
 	}
 
+	branchNumberToCheckout := -1
 	// listen for input
 	reader := bufio.NewReader(os.Stdin)
-	fmt.Print("Enter the number next to the branch name to switch: ")
-	text, _ := reader.ReadString('\n')
 
-	inputInt, err := strconv.Atoi(strings.TrimSuffix(text, "\n"))
-	if err != nil {
-		return "", errors.New("input must be a number")
+	for branchNumberToCheckout == -1 {
+		fmt.Println("Enter the number next to the branch name to switch: ")
+		text, _ := reader.ReadString('\n')
+
+		inputInt, err := strconv.Atoi(strings.TrimSuffix(text, "\n"))
+		if err != nil {
+			color.Red("input must be a number")
+		} else if inputInt < 0 || inputInt > len(normalisedBranchNames)-1 {
+			color.Red("Branch number is invalid. Please enter one of the numbers next to the branch name")
+		} else {
+			branchNumberToCheckout = inputInt
+		}
 	}
 
-	if inputInt < 0 || inputInt > len(normalisedBranchNames)-1 {
-		return "", errors.New("Branch number is invalid. Please enter one of the numbers next to the branch number")
-	}
-
-	branchToCheckout := normalisedBranchNames[inputInt]
+	branchToCheckout := normalisedBranchNames[branchNumberToCheckout]
 	gitCheckoutCmd := exec.Command("git", "checkout", strings.TrimSpace(branchToCheckout))
 	gitCheckoutStdStderr, gitCheckoutErr := gitCheckoutCmd.CombinedOutput()
 

--- a/internal/commands/show.go
+++ b/internal/commands/show.go
@@ -54,7 +54,7 @@ func Show() (string, error) {
 
 	// loop until we get a valid branch number
 	for branchNumberToCheckout == -1 {
-		fmt.Println("Enter the number next to the branch name to switch: ")
+		fmt.Print("Enter the number next to the branch name to switch: ")
 		text, _ := reader.ReadString('\n')
 
 		inputInt, err := strconv.Atoi(strings.TrimSuffix(text, "\n"))

--- a/internal/commands/show.go
+++ b/internal/commands/show.go
@@ -8,6 +8,8 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+
+	"github.com/fatih/color"
 )
 
 func Show() {
@@ -26,11 +28,15 @@ func Show() {
 	}
 
 	branches := strings.Split(bytesToString(gitBranchesStdoutStderr), "\n")
-	// TODO: remove the * from the current branch
 
-	for index, element := range branches {
-		if len(element) > 0 {
-			fmt.Printf("%d) %v\n", index, element)
+	for index, branch := range branches {
+		if len(branch) > 0 {
+			if isCurrentBranch(branch) {
+				normalisedBranchName := strings.Replace(branch, "* ", "", 1)
+				color.Green("%d)   %v\n", index, normalisedBranchName)
+			} else {
+				fmt.Printf("%d) %v\n", index, branch)
+			}
 		}
 	}
 
@@ -40,11 +46,10 @@ func Show() {
 	text, _ := reader.ReadString('\n')
 
 	inputInt, err := strconv.Atoi(strings.TrimSuffix(text, "\n"))
-	// TODO: Need to handle when the input is not within the valid range
-
 	if err != nil {
 		log.Fatal(err)
 	}
+	// TODO: Need to handle when the input is not within the valid range
 
 	branchToCheckout := branches[inputInt]
 	gitCheckoutCmd := exec.Command("git", "checkout", strings.TrimSpace(branchToCheckout))
@@ -60,4 +65,8 @@ func Show() {
 // https://gist.github.com/is73/de4f38e1d8da157fe33e
 func bytesToString(data []byte) string {
 	return string(data[:])
+}
+
+func isCurrentBranch(s string) bool {
+	return strings.HasPrefix(s, "*")
 }

--- a/internal/commands/show.go
+++ b/internal/commands/show.go
@@ -13,7 +13,7 @@ import (
 )
 
 func Show() (string, error) {
-	gitBranchesCmd := exec.Command("git", "branch", "--list")
+	gitBranchesCmd := exec.Command("git", "branch", "-a")
 	gitBranchesStdoutStderr, gitBranchesErr := gitBranchesCmd.CombinedOutput()
 
 	if gitBranchesErr != nil {
@@ -26,18 +26,19 @@ func Show() (string, error) {
 
 	for _, branch := range branches {
 		if len(branch) > 0 {
-			if isCurrentBranch(branch) {
-				onlyBranchName := strings.Replace(branch, "* ", "", 1)
-				coloredBranchName := color.GreenString("  %v", onlyBranchName)
+			trimmedBranch := strings.TrimSpace(branch)
+			if isCurrentBranch(trimmedBranch) {
+				onlyBranchName := strings.Replace(trimmedBranch, "* ", "", 1)
+				coloredBranchName := color.GreenString("%v", onlyBranchName)
 				normalisedBranchNames = append(normalisedBranchNames, coloredBranchName)
 			} else {
-				normalisedBranchNames = append(normalisedBranchNames, branch)
+				normalisedBranchNames = append(normalisedBranchNames, trimmedBranch)
 			}
 		}
 	}
 
 	for index, branch := range normalisedBranchNames {
-		fmt.Printf("%d) %v\n", index, branch)
+		fmt.Printf("%d)\t%v\n", index, branch)
 	}
 
 	branchNumberToCheckout := -1

--- a/internal/commands/show.go
+++ b/internal/commands/show.go
@@ -28,10 +28,11 @@ func Show() (string, error) {
 		if len(branch) > 0 {
 			if isCurrentBranch(branch) {
 				onlyBranchName := strings.Replace(branch, "* ", "", 1)
-				coloredBranchName := color.GreenString(onlyBranchName)
+				coloredBranchName := color.GreenString("  %v", onlyBranchName)
 				normalisedBranchNames = append(normalisedBranchNames, coloredBranchName)
+			} else {
+				normalisedBranchNames = append(normalisedBranchNames, branch)
 			}
-			normalisedBranchNames = append(normalisedBranchNames, branch)
 		}
 	}
 

--- a/internal/commands/show.go
+++ b/internal/commands/show.go
@@ -2,8 +2,8 @@ package commands
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
-	"log"
 	"os"
 	"os/exec"
 	"strconv"
@@ -12,12 +12,12 @@ import (
 	"github.com/fatih/color"
 )
 
-func Show() {
+func Show() (string, error) {
 	gitBranchesCmd := exec.Command("git", "branch", "--list")
 	gitBranchesStdoutStderr, gitBranchesErr := gitBranchesCmd.CombinedOutput()
 
 	if gitBranchesErr != nil {
-		log.Fatal(bytesToString(gitBranchesStdoutStderr))
+		return "", errors.New(bytesToString(gitBranchesStdoutStderr))
 	}
 
 	branches := strings.Split(bytesToString(gitBranchesStdoutStderr), "\n")
@@ -46,11 +46,11 @@ func Show() {
 
 	inputInt, err := strconv.Atoi(strings.TrimSuffix(text, "\n"))
 	if err != nil {
-		log.Fatal(err)
+		return "", errors.New("input must be a number")
 	}
 
 	if inputInt < 0 || inputInt > len(onlyBranchNames)-1 {
-		log.Fatal("Branch number is invalid. Please enter one of the numbers next to the branch number")
+		return "", errors.New("Branch number is invalid. Please enter one of the numbers next to the branch number")
 	}
 
 	branchToCheckout := onlyBranchNames[inputInt]
@@ -58,10 +58,10 @@ func Show() {
 	gitCheckoutStdStderr, gitCheckoutErr := gitCheckoutCmd.CombinedOutput()
 
 	if gitCheckoutErr != nil {
-		log.Fatal(bytesToString(gitCheckoutStdStderr))
+		return "", errors.New(bytesToString(gitCheckoutStdStderr))
 	}
 
-	fmt.Print(bytesToString(gitCheckoutStdStderr))
+	return bytesToString(gitCheckoutStdStderr), nil
 }
 
 // https://gist.github.com/is73/de4f38e1d8da157fe33e

--- a/internal/commands/show.go
+++ b/internal/commands/show.go
@@ -13,7 +13,7 @@ import (
 )
 
 func Show() (string, error) {
-	gitBranchesCmd := exec.Command("git", "branch", "-a")
+	gitBranchesCmd := exec.Command("git", "branch", "--list")
 	gitBranchesStdoutStderr, gitBranchesErr := gitBranchesCmd.CombinedOutput()
 
 	if gitBranchesErr != nil {

--- a/internal/commands/show.go
+++ b/internal/commands/show.go
@@ -15,7 +15,7 @@ func Show() {
 	gitBranchesStdoutStderr, gitBranchesErr := gitBranchesCmd.CombinedOutput()
 
 	if gitBranchesErr != nil {
-		log.Fatal(gitBranchesErr)
+		log.Fatal(bytesToString(gitBranchesStdoutStderr))
 	}
 
 	gitCurrentBranchCmd := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
@@ -25,17 +25,10 @@ func Show() {
 		log.Fatal(gitCurrentBranchErr)
 	}
 
-	fmt.Printf("all branches: %q\n", gitBranchesStdoutStderr)
-	fmt.Printf("current branch: %q\n", gitCurrentBranchStdoutStderr)
-
-	// split all branches on \n
 	branches := strings.Split(bytesToString(gitBranchesStdoutStderr), "\n")
-	// remove the * from the current branch
+	// TODO: remove the * from the current branch
 
-	fmt.Printf("total amount of branches is: %d\n", len(branches))
-	// map each branch with it's index
 	for index, element := range branches {
-		fmt.Println("mapping the branches:")
 		if len(element) > 0 {
 			fmt.Printf("%d) %v\n", index, element)
 		}
@@ -45,29 +38,23 @@ func Show() {
 	reader := bufio.NewReader(os.Stdin)
 	fmt.Print("Enter text: ")
 	text, _ := reader.ReadString('\n')
-	fmt.Printf("input: %v", text)
-	// if input matches a branch number:
+
 	inputInt, err := strconv.Atoi(strings.TrimSuffix(text, "\n"))
+	// TODO: Need to handle when the input is not within the valid range
 
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	branchToCheckout := branches[inputInt]
-
-	fmt.Println("branch to checkout:")
-	fmt.Println(branchToCheckout)
-	fmt.Println(len(branchToCheckout))
-	fmt.Println(len(strings.TrimSpace(branchToCheckout)))
-	// checkout that branch
 	gitCheckoutCmd := exec.Command("git", "checkout", strings.TrimSpace(branchToCheckout))
 	gitCheckoutStdStderr, gitCheckoutErr := gitCheckoutCmd.CombinedOutput()
 
 	if gitCheckoutErr != nil {
-		log.Fatal(gitCheckoutErr)
+		log.Fatal(bytesToString(gitCheckoutStdStderr))
 	}
 
-	fmt.Printf("blah: %q", gitCheckoutStdStderr)
+	fmt.Print(bytesToString(gitCheckoutStdStderr))
 }
 
 // https://gist.github.com/is73/de4f38e1d8da157fe33e

--- a/internal/commands/show.go
+++ b/internal/commands/show.go
@@ -41,13 +41,17 @@ func Show() (string, error) {
 		cols = 2
 	}
 
+	fmt.Print("Your available local branches are:\n\n")
+
 	for index, branch := range normalisedBranchNames {
 		if branch == currentBranch {
-			color.Green("%s)\t%v\n", alignRight(index, cols), branch)
+			color.Green(" * %s  %v\n", alignRight(index, cols), branch)
 		} else {
-			fmt.Printf("%s)\t%v\n", alignRight(index, cols), branch)
+			fmt.Printf("   %s  %v\n", alignRight(index, cols), branch)
 		}
 	}
+
+	fmt.Print("\n")
 
 	branchNumberToCheckout := -1
 	reader := bufio.NewReader(os.Stdin)

--- a/internal/commands/show.go
+++ b/internal/commands/show.go
@@ -22,29 +22,16 @@ func Show() (string, error) {
 
 	branches := strings.Split(bytesToString(gitBranchesStdoutStderr), "\n")
 
-	var normalisedBranchNames []string
-
-	for _, branch := range branches {
-		if len(branch) > 0 {
-			trimmedBranch := strings.TrimSpace(branch)
-			if isCurrentBranch(trimmedBranch) {
-				onlyBranchName := strings.Replace(trimmedBranch, "* ", "", 1)
-				coloredBranchName := color.GreenString("%v", onlyBranchName)
-				normalisedBranchNames = append(normalisedBranchNames, coloredBranchName)
-			} else {
-				normalisedBranchNames = append(normalisedBranchNames, trimmedBranch)
-			}
-		}
-	}
+	var normalisedBranchNames = normaliseGitBranchOutput(branches)
 
 	for index, branch := range normalisedBranchNames {
 		fmt.Printf("%d)\t%v\n", index, branch)
 	}
 
 	branchNumberToCheckout := -1
-	// listen for input
 	reader := bufio.NewReader(os.Stdin)
 
+	// loop until we get a valid branch number
 	for branchNumberToCheckout == -1 {
 		fmt.Println("Enter the number next to the branch name to switch: ")
 		text, _ := reader.ReadString('\n')
@@ -59,6 +46,7 @@ func Show() (string, error) {
 		}
 	}
 
+	// checkout the branch
 	branchToCheckout := normalisedBranchNames[branchNumberToCheckout]
 	gitCheckoutCmd := exec.Command("git", "checkout", strings.TrimSpace(branchToCheckout))
 	gitCheckoutStdStderr, gitCheckoutErr := gitCheckoutCmd.CombinedOutput()
@@ -77,4 +65,23 @@ func bytesToString(data []byte) string {
 
 func isCurrentBranch(s string) bool {
 	return strings.HasPrefix(s, "*")
+}
+
+func normaliseGitBranchOutput(branches []string) []string {
+	var normalisedBranchNames []string
+
+	for _, branch := range branches {
+		if len(branch) > 0 {
+			trimmedBranch := strings.TrimSpace(branch)
+			if isCurrentBranch(trimmedBranch) {
+				onlyBranchName := strings.Replace(trimmedBranch, "* ", "", 1)
+				coloredBranchName := color.GreenString("%v", onlyBranchName)
+				normalisedBranchNames = append(normalisedBranchNames, coloredBranchName)
+			} else {
+				normalisedBranchNames = append(normalisedBranchNames, trimmedBranch)
+			}
+		}
+	}
+
+	return normalisedBranchNames
 }


### PR DESCRIPTION
This PR is the initial implementation of `gg show`. It lists all local branches and provides an interactive way to switch the branch. If any errors from git itself are bubbled up, so any non gg specific error handling is being done for us by git. At first glance there's quite a few concepts mashed into this one class, which I suspect we'll start to abstract as we create more commands and common patterns emerge.

## Examples
```
👉  go build -o gg && ./gg show
0)	change-main-file-name
1)	create_cli_structure
2)	implement-show
3)	interactive-branch-switch
4)	master
Enter the number next to the branch name to switch:
4
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
```
